### PR TITLE
split junit-dep into junit and hamcrest-core

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,10 +11,18 @@
     <description>Who is the replicant here?</description>
 
     <dependencies>
+
         <!--main-->
         <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-core</artifactId>
+            <version>1.1</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>junit</groupId>
-            <artifactId>junit-dep</artifactId>
+            <artifactId>junit</artifactId>
             <version>4.8.2</version>
             <scope>test</scope>
         </dependency>


### PR DESCRIPTION
After running tests with different settings in pom.xml, I kind of solved the issue(#2) by switching "junit-dep" to just "junit (not internally dependent on hamcrest)" with the version of 4.8.2

Since "junit-dep 4.8.2" is dependent on "hamcrest 1.1", I added it as well. 
