### PR TITLE
Update docs for Mavericks

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ To start a new Android project:
     ```bash
     android
     ```
-4. Install Maven if you haven't already (run `mvn` to check). On OS X (as before) this is easiest with [Homebrew](http://brew.sh/) (unfortuanetly we have to install Maven 3.0.x as Maven 3.1.x is currently buggy on OS X):
+4. Install Maven if you haven't already (run `mvn` to check). On OS X (as before) this is easiest with [Homebrew](http://brew.sh/) (unfortunately we have to install Maven 3.0.x as Maven 3.1.x is currently buggy on OS X):
 	```bash
 	brew install homebrew/versions/maven30
 	```


### PR DESCRIPTION
OS X Mavericks has removed the automagic installer for the JDK and also doesn't come with Maven installed. Adding some info to the docs to make sure people know what they're doing.
