### PR TITLE
Remove Hamcrest dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,13 +14,6 @@
 
         <!--main-->
         <dependency>
-            <groupId>org.hamcrest</groupId>
-            <artifactId>hamcrest-core</artifactId>
-            <version>1.1</version>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <version>4.8.2</version>


### PR DESCRIPTION
As per the discussion in #4 we don't really want to have an assertion library included in Deckard.
