### PR TITLE
m2e-android compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,10 @@
 Deckard is the simplest possible Android project that uses Robolectric for testing and Maven to build. It has one Activity (with an empty layout), and a Robolectric test that creates that Activity. 
 
 Deckard also imports seamlessly into IntelliJ, due to IntelliJ's support for Maven. Just import the pom.xml.
+
 Eclipse is also supported. Install the [m2e-android](http://rgladwell.github.io/m2e-android/) plugin for Eclipse, and import the project as a Maven project.
+After importing into Eclipse, you have to mark the consume-aar goal as ignored, since aar consumption is not yet supported by m2e-android.
+To do this, simply apply the Quick fix on the "Plugin execution not covered by lifecycle configuration" error.
 
 ## Setup
 

--- a/pom.xml
+++ b/pom.xml
@@ -73,40 +73,5 @@
                 </configuration>
             </plugin>
         </plugins>
-        <pluginManagement>
-        	<plugins>
-        		<!--This plugin's configuration is used to store Eclipse m2e settings only. It has no influence on the Maven build itself.-->
-        		<plugin>
-        			<groupId>org.eclipse.m2e</groupId>
-        			<artifactId>lifecycle-mapping</artifactId>
-        			<version>1.0.0</version>
-        			<configuration>
-        				<lifecycleMappingMetadata>
-        					<pluginExecutions>
-        						<pluginExecution>
-        							<pluginExecutionFilter>
-        								<groupId>
-        									com.jayway.maven.plugins.android.generation2
-        								</groupId>
-        								<artifactId>
-        									android-maven-plugin
-        								</artifactId>
-        								<versionRange>
-        									[3.8.0,)
-        								</versionRange>
-        								<goals>
-        									<goal>consume-aar</goal>
-        								</goals>
-        							</pluginExecutionFilter>
-        							<action>
-        								<ignore></ignore>
-        							</action>
-        						</pluginExecution>
-        					</pluginExecutions>
-        				</lifecycleMappingMetadata>
-        			</configuration>
-        		</plugin>
-        	</plugins>
-        </pluginManagement>
     </build>
 </project>


### PR DESCRIPTION
This commit adds the project.properties file and marks the
maven-android-plugin goal consume-aar ignored in m2e build. The project
now can be imported into eclipse and the tests can be run without any
further config using the m2e-android plugin.
